### PR TITLE
balance_transaction is optional when capture = false

### DIFF
--- a/src/resources/charge.rs
+++ b/src/resources/charge.rs
@@ -161,7 +161,7 @@ pub struct Charge {
     pub amount_refunded: u64,
     pub application: Option<String>,
     pub application_fee: Option<String>,
-    pub balance_transaction: String,
+    pub balance_transaction: Option<String>,
     pub captured: bool,
     pub created: Timestamp,
     pub currency: Currency,


### PR DESCRIPTION
`balance_transaction` is optional when the Charge parameter `capture` is set to false. The Stripe response for an uncaptured charge cannot be deserialized to `stripe::Charge` in the current setup.