### PR TITLE
Temporarily update travis to ignore beta failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+
+    # See https://github.com/briansmith/ring/issues/598
+    - rust: beta


### PR DESCRIPTION
This is due to an issue with the ring crate ignoring a deprecation in rust (see https://github.com/briansmith/ring/issues/598) and can't be fixed until our dependencies update or Ring back-ports a fix for the issue.

As a work around if you are using nightly or beta, you can configure the crate with:

    default_features = false
    features = ['with-openssl']