### PR TITLE
fix subscription plan member "name"

### DIFF
--- a/src/resources/plan.rs
+++ b/src/resources/plan.rs
@@ -42,7 +42,7 @@ pub struct Plan {
     pub interval_count: u64,
     pub livemode: bool,
     pub metadata: Metadata,
-    pub name: String,
+    pub nickname: String,
     pub statement_descriptor: Option<String>,
     pub trial_period_days: Option<u64>,
 }


### PR DESCRIPTION
In `Subscription`, `Plan`, the member property `name` should actually be `nickname`. See https://stripe.com/docs/api#plans. 